### PR TITLE
refactor: made configs abstract to account for more reference domains

### DIFF
--- a/builds/build_reference.py
+++ b/builds/build_reference.py
@@ -1,11 +1,11 @@
-"""An end-to-end build file that will take the NHD PRVI and turn it into a reference fabric"""
+"""An end-to-end build file that will take the NHD ReferenceConfig and turn it into a reference fabric"""
 
 import argparse
 import logging
 
 from pydantic import ValidationError
 
-from reference_builds.configs import PRVI
+from reference_builds.configs import ReferenceConfig
 from reference_builds.local_runner import LocalRunner
 from reference_builds.pipeline import build_graphs, build_reference, download_nhd_data, write_reference
 
@@ -25,7 +25,7 @@ def main() -> int:
     args = parser.parse_args()
 
     try:
-        config = PRVI.from_yaml(args.config)
+        config = ReferenceConfig.from_yaml(args.config)
     except ValidationError as e:
         print("Configuration validation failed:")
         for error in e.errors():

--- a/config/example_hi.yaml
+++ b/config/example_hi.yaml
@@ -1,0 +1,4 @@
+domain: hi
+input_file_regex: HI/NHDPLUS_H_20*_HU4_GPKG
+vpu_id: "20"
+crs: EPSG:32604

--- a/config/example_prvi.yaml
+++ b/config/example_prvi.yaml
@@ -1,2 +1,4 @@
-output_dir: data/
+domain: prvi
+input_file_regex: PRVI/NHDPLUS_H_21*_HU4_GPKG
+vpu_id: "21"
 crs: EPSG:6566

--- a/src/reference_builds/configs/__init__.py
+++ b/src/reference_builds/configs/__init__.py
@@ -1,3 +1,3 @@
-from .prvi import PRVI
+from .reference_config import ReferenceConfig
 
-__all__ = ["PRVI"]
+__all__ = ["ReferenceConfig"]

--- a/src/reference_builds/configs/reference_config.py
+++ b/src/reference_builds/configs/reference_config.py
@@ -10,25 +10,26 @@ from pyprojroot import here
 from reference_builds import __version__
 
 
-class PRVI(BaseModel):
-    """Configs for building the PRVI reference"""
+class ReferenceConfig(BaseModel):
+    """Configs for building the ReferenceConfig reference"""
 
     output_dir: Path = Field(
         default=here() / "data/",
         description="The directory for output files to be saved from Hydrofabric builds",
     )
 
+    domain: str = Field(description="The domain used for the building your reference")
+
     input_file_regex: str = Field(
-        default="PRVI/NHDPLUS_H_21*_HU4_GPKG",
         description="input file to be converted into a reference product",
     )
 
     crs: str = Field(
-        default="EPSG:6566",
-        description="Coordinate Reference System for the PRVI reference builds. Defaults to https://epsg.io/6566",
+        default="EPSG:4326",
+        description="Coordinate Reference System for the domain reference builds. Defaults to https://epsg.io/4326",
     )
 
-    vpu_id: str = Field(default="21", description="The VPUID for PRVI")
+    vpu_id: str = Field(description="The VPUID for the domain")
 
     write_gpkg: bool = Field(
         default=True, description="Writes a geopackage in addition to parquet files for output"
@@ -47,18 +48,20 @@ class PRVI(BaseModel):
     )
 
     output_reference_gpkg_path: Path = Field(
-        default_factory=lambda data: data["output_dir"] / f"prvi_{__version__}_reference.gpkg",
-        description="Save directory for the PRVI reference (in .gpkg form)",
+        default_factory=lambda data: data["output_dir"] / f"{data['domain']}_{__version__}_reference.gpkg",
+        description="Save directory for the domain's reference (in .gpkg form)",
     )
 
     output_reference_divides_path: Path = Field(
-        default_factory=lambda data: data["output_dir"] / f"prvi_{__version__}_reference_divides.parquet",
-        description="Save directory for the PRVI reference divides",
+        default_factory=lambda data: data["output_dir"]
+        / f"{data['domain']}_{__version__}_reference_divides.parquet",
+        description="Save directory for the domain's reference divides",
     )
 
     output_reference_flowpaths_path: Path = Field(
-        default_factory=lambda data: data["output_dir"] / f"prvi_{__version__}_reference_flowpaths.parquet",
-        description="Save directory for the PRVI reference flowpaths",
+        default_factory=lambda data: data["output_dir"]
+        / f"{data['domain']}_{__version__}_reference_flowpaths.parquet",
+        description="Save directory for the domain's reference flowpaths",
     )
 
     @classmethod

--- a/src/reference_builds/local_runner.py
+++ b/src/reference_builds/local_runner.py
@@ -4,7 +4,7 @@ from collections.abc import Callable
 from datetime import datetime
 from typing import Any, Self
 
-from reference_builds.configs import PRVI
+from reference_builds.configs import ReferenceConfig
 from reference_builds.logs import setup_logging
 from reference_builds.task_instance import TaskInstance
 
@@ -34,7 +34,7 @@ class LocalRunner:
 
     def __init__(
         self,
-        config: PRVI,
+        config: ReferenceConfig,
         run_id: str | None = None,
     ) -> None:
         """Initialize the LocalRunner.
@@ -46,7 +46,7 @@ class LocalRunner:
         run_id : str or None, default=None
             Optional run identifier. Auto-generated if not provided.
         """
-        self.config: PRVI = config
+        self.config: ReferenceConfig = config
         self.run_id: str = run_id or datetime.now().strftime("%Y%m%d_%H%M%S")
         self.ti: TaskInstance = TaskInstance()
         self.results: dict[str, dict[str, Any]] = {}

--- a/src/reference_builds/pipeline/build_reference.py
+++ b/src/reference_builds/pipeline/build_reference.py
@@ -8,7 +8,7 @@ import pandas as pd
 import polars as pl
 import rustworkx as rx
 
-from reference_builds.configs import PRVI
+from reference_builds.configs import ReferenceConfig
 from reference_builds.task_instance import TaskInstance
 
 logger = logging.getLogger(__name__)
@@ -282,7 +282,7 @@ def build_reference(**context: dict[str, Any]) -> dict[str, Any]:
         The reference flowpath and divides references in memory
     """
     ti = cast(TaskInstance, context["ti"])
-    cfg = cast(PRVI, context["config"])
+    cfg = cast(ReferenceConfig, context["config"])
     graph: rx.PyDiGraph = ti.xcom_pull(task_id="build_graphs", key="graph")
     node_indices: dict[str, int] = ti.xcom_pull(task_id="build_graphs", key="node_indices")
     _flowpaths: pl.DataFrame = ti.xcom_pull(task_id="download", key="nhd_flowpaths")

--- a/src/reference_builds/pipeline/download.py
+++ b/src/reference_builds/pipeline/download.py
@@ -8,7 +8,7 @@ import geopandas as gpd
 import pandas as pd
 import polars as pl
 
-from reference_builds.configs import PRVI
+from reference_builds.configs import ReferenceConfig
 from reference_builds.utils import _validate_and_fix_geometries
 
 logger = logging.getLogger(__name__)
@@ -42,7 +42,7 @@ def download_nhd_data(**context: dict[str, Any]) -> dict[str, pl.DataFrame]:
     dict[str, pl.DataFrame]
         The reference flowpath and divides references in memory
     """
-    cfg = cast(PRVI, context["config"])
+    cfg = cast(ReferenceConfig, context["config"])
 
     # find the gpkg files from the ScienceBase NHD folders
     matching_folders = list(cfg.output_dir.glob(cfg.input_file_regex))

--- a/src/reference_builds/pipeline/processing.py
+++ b/src/reference_builds/pipeline/processing.py
@@ -65,6 +65,14 @@ def _build_graph(connectivity: pl.DataFrame, flowpaths: pl.DataFrame) -> dict[st
         )
     )
 
+    all_flowpath_ids = flowpaths.select(pl.col("NHDPlusID").cast(pl.Int64).cast(pl.Utf8))[
+        "NHDPlusID"
+    ].to_list()
+
+    for fp_id in all_flowpath_ids:
+        if fp_id not in upstream_dict:
+            upstream_dict[fp_id] = []
+
     return upstream_dict
 
 

--- a/src/reference_builds/pipeline/write.py
+++ b/src/reference_builds/pipeline/write.py
@@ -3,7 +3,7 @@
 import logging
 from typing import Any, cast
 
-from reference_builds.configs import PRVI
+from reference_builds.configs import ReferenceConfig
 from reference_builds.task_instance import TaskInstance
 
 logger = logging.getLogger(__name__)
@@ -28,7 +28,7 @@ def write_reference(**context: dict[str, Any]) -> dict[str, Any]:
     dict[str, Any]
         The reference flowpath and divides references in memory
     """
-    cfg = cast(PRVI, context["config"])
+    cfg = cast(ReferenceConfig, context["config"])
     ti = cast(TaskInstance, context["ti"])
     cfg.output_reference_flowpaths_path.unlink(missing_ok=True)  # deletes files that exist with the same name
     cfg.output_reference_divides_path.unlink(missing_ok=True)  # deletes files that exist with the same name

--- a/tests/test_builds.py
+++ b/tests/test_builds.py
@@ -27,7 +27,9 @@ class TestTraceAttributes:
 
         expected_columns = {
             "flowpath_id",
+            "flowpath_toid",
             "VPUID",
+            "lengthkm",
             "areasqkm",
             "totdasqkm",
             "mainstemlp",


### PR DESCRIPTION
## Issue Addressed

abstracted the configuration classes to allow for ScienceBase NHD domains from other regions. Made a new reference for hawaii using `uv run python builds/build_reference.py --config config/example_hi.yaml`

<img width="1568" height="592" alt="image" src="https://github.com/user-attachments/assets/2075c4b2-0a88-4027-8b7a-9371b1f4867b" />


## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code cleanup/refactor
- [ ] Documentation update

Other (please specify):

## Checklist

- [ ] Branch is up to date with master
- [ ] Updated tests or added new tests
- [ ] Tests & pre-commit hooks pass
- [ ] Updated documentation (if applicable)
- [ ] Code follows established style and conventions
